### PR TITLE
refactor: add global parameters

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,9 @@
 import axios from "axios";
 
 export const api = axios.create({
-  baseURL: `http://api.weatherapi.com/v1/`
+  baseURL: `http://api.weatherapi.com/v1/`,
+  params: {
+    key: process.env.API_KEY,
+  },
 })
 


### PR DESCRIPTION
That way it won't be necessary to pass the API_KEY every time you need it.